### PR TITLE
Linear instead of All-NonLinear

### DIFF
--- a/src/nonlinear_algorithm.jl
+++ b/src/nonlinear_algorithm.jl
@@ -261,7 +261,7 @@ function populatelinearmatrix(m::PajaritoNonlinearModel)
         push!(A_I,row); push!(A_J, jac_J[k]); push!(A_V, jac_V[k])
     end
 
-    m.A = sparse(A_I, A_J, A_V, m.numConstr-m.numNLConstr, m.numVar)
+    m.A = sparse(A_I, A_J, A_V, numlinear, m.numVar)
 
     # g(x) might have a constant, i.e., a'x + b
     # let's find b


### PR DESCRIPTION
The sparse matrix should use the number of linear constraints in my opinion instead of all constraints - the non linear ones.
Makes it easier to read and the variable is already defined.